### PR TITLE
Batasi slug statis dan izinkan render dinamis

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is a starter template for building a Next.js application that fetches data 
 - `components/posts/search-input.tsx` -> Search component for Posts
 - `menu.config.ts` -> Site nav menu configuration for desktop and mobile
 - `site.config.ts` -> Configuration for `sitemap.ts` and more
+- `MAX_STATIC_SLUGS` -> Batas jumlah slug yang di-render statik dalam `getAllPostSlugs`
 - `app/sitemap.ts` -> Dynamically generated sitemap
 
 The following environment variables are required in your `.env.local` file:

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -16,6 +16,8 @@ import Balancer from "react-wrap-balancer";
 
 import type { Metadata } from "next";
 
+export const dynamicParams = true;
+
 export async function generateStaticParams() {
   return await getAllPostSlugs();
 }

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -11,6 +11,7 @@ import type {
   Author,
   FeaturedMedia,
 } from "./wordpress.d";
+import { MAX_STATIC_SLUGS } from "@/site.config";
 
 const baseUrl = process.env.WORDPRESS_URL;
 
@@ -354,7 +355,7 @@ export async function getAllPostSlugs(): Promise<{ slug: string }[]> {
   let page = 1;
   let hasMore = true;
 
-  while (hasMore) {
+  while (hasMore && allSlugs.length < MAX_STATIC_SLUGS) {
     const response = await wordpressFetchWithPagination<Post[]>(
       "/wp-json/wp/v2/posts",
       {
@@ -366,6 +367,11 @@ export async function getAllPostSlugs(): Promise<{ slug: string }[]> {
 
     const posts = response.data;
     allSlugs.push(...posts.map((post) => ({ slug: post.slug })));
+
+    if (allSlugs.length >= MAX_STATIC_SLUGS) {
+      allSlugs.splice(MAX_STATIC_SLUGS);
+      break;
+    }
 
     hasMore = page < response.headers.totalPages;
     page++;

--- a/site.config.ts
+++ b/site.config.ts
@@ -4,6 +4,9 @@ type SiteConfig = {
   site_description: string;
 };
 
+// Jumlah maksimal slug yang dirender secara statik
+export const MAX_STATIC_SLUGS = 100;
+
 export const siteConfig: SiteConfig = {
   site_name: "next-wp",
   site_description: "Starter template for Headless WordPress with Next.js",


### PR DESCRIPTION
## Ringkasan
- menambah konstanta `MAX_STATIC_SLUGS` pada `site.config.ts`
- mengimpor konstanta tersebut di `lib/wordpress.ts` dan menghentikan loop `getAllPostSlugs` setelah batas tercapai
- mengaktifkan `dynamicParams` pada rute `/posts/[slug]`
- memperbarui README dengan penjelasan singkat konstanta baru

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685e7a87d2f08325bf348ffd11ae1f1d