### PR TITLE
Pulihkan slider di beranda

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import Balancer from "react-wrap-balancer";
 import { PostCard } from "@/components/posts/post-card";
 import { HeroPost } from "@/components/posts/hero-post";
 import { SidebarPost } from "@/components/posts/sidebar-post";
-import { RandomWeekPosts } from "@/components/posts/random-week-posts";
+import { PostSlider } from "@/components/posts/post-slider";
 import { getPostsPaginated } from "@/lib/wordpress";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -51,7 +51,7 @@ export default async function Home() {
       />
       <Section className="py-4">
         <Container>
-          <RandomWeekPosts />
+          <PostSlider />
         </Container>
       </Section>
       <Section>

--- a/components/posts/post-slider-client.tsx
+++ b/components/posts/post-slider-client.tsx
@@ -4,6 +4,7 @@ import { useKeenSlider } from 'keen-slider/react'
 import 'keen-slider/keen-slider.min.css'
 import Link from 'next/link'
 import Image from 'next/image'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 export interface SliderItem {
   id: number
@@ -49,14 +50,14 @@ export function PostSliderClient({ posts }: { posts: SliderItem[] }) {
         className="absolute left-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-8 h-8 rounded-full border bg-background/90 hover:bg-accent transition-colors"
         onClick={() => instanceRef.current?.prev()}
       >
-        «
+        <ChevronLeft className="w-4 h-4" />
       </button>
       <button
         aria-label="Berikutnya"
         className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-8 h-8 rounded-full border bg-background/90 hover:bg-accent transition-colors"
         onClick={() => instanceRef.current?.next()}
       >
-        »
+        <ChevronRight className="w-4 h-4" />
       </button>
     </div>
   )

--- a/components/posts/post-slider.tsx
+++ b/components/posts/post-slider.tsx
@@ -1,8 +1,8 @@
-import { getRecentPosts, getFeaturedMediaById } from '@/lib/wordpress'
+import { getRandomWeeklyPosts, getFeaturedMediaById } from '@/lib/wordpress'
 import { PostSliderClient, SliderItem } from './post-slider-client'
 
 export async function PostSlider() {
-  const posts = await getRecentPosts(8)
+  const posts = await getRandomWeeklyPosts(8)
   const items: SliderItem[] = await Promise.all(
     posts.map(async (post) => {
       const media = post.featured_media


### PR DESCRIPTION
## Ringkasan
- tampilkan kembali komponen `PostSlider`
- `PostSlider` kini memuat posting acak dari 1 minggu terakhir
- perbarui tombol navigasi slider menggunakan ikon

## Testing
- `pnpm lint`
- `pnpm build` *(gagal: `WORDPRESS_URL` belum disetel)*

------
https://chatgpt.com/codex/tasks/task_b_685fbb22e06083258390efa58643f17e