### PR TITLE
Perbaikan posisi gambar pada desktop

### DIFF
--- a/components/craft.tsx
+++ b/components/craft.tsx
@@ -155,6 +155,8 @@ const styles = {
     ],
     media: [
       "[&_img]:rounded-lg [&_img]:border [&_img]:my-4 [&_img]:max-w-full [&_img]:h-auto",
+      "[&_img.aligncenter]:block [&_img.aligncenter]:mx-auto",
+      "[&_figure.aligncenter]:mx-auto [&_figure.aligncenter_img]:mx-auto",
       "[&_video]:rounded-lg [&_video]:border [&_video]:my-4",
       "[&_figure]:my-4",
       "[&_figure_img]:my-0",


### PR DESCRIPTION
## Ringkasan
- menambahkan aturan CSS untuk class `aligncenter` pada gambar dan figure
- gambar dengan class `aligncenter` sekarang ditampilkan di tengah sesuai post asli

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685ff492266c83258b569e4594d19a8d