### PR TITLE
Implement song page with new music API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ WORDPRESS_HOSTNAME="wordpress.com"
 # If using the revalidate plugin
 # You can generate by running `openssl rand -base64 32` in the terminal
 WORDPRESS_WEBHOOK_SECRET="your-secret-key-here"
+MUSIC_API_URL="http://localhost:5000/music"

--- a/app/song/[title]/page.tsx
+++ b/app/song/[title]/page.tsx
@@ -1,0 +1,67 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Section, Container, Prose } from "@/components/craft";
+import { getSongByTitle } from "@/lib/music";
+
+export const revalidate = 3600;
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ title: string }>;
+}) {
+  const { title } = await params;
+  const song = await getSongByTitle(title);
+
+  if (!song) {
+    return (
+      <Section>
+        <Container>
+          <Prose>
+            <h2>Lagu tidak ditemukan</h2>
+            <p>Data lagu gagal diambil.</p>
+          </Prose>
+        </Container>
+      </Section>
+    );
+  }
+
+  return (
+    <Section>
+      <Container className="space-y-6">
+        <Prose>
+          <h2>{song.title}</h2>
+          <p>
+            Album: {" "}
+            <Link href={`/album/${song.album.id}`}>{song.album.name}</Link>
+          </p>
+          <p>
+            Artist: {" "}
+            {song.artists.map((artist, idx) => (
+              <span key={artist.id}>
+                {idx > 0 && ", "}
+                <Link href={`/artist/${artist.id}`}>{artist.name}</Link>
+              </span>
+            ))}
+          </p>
+          <p>Durasi: {song.duration}</p>
+          <p>Ditonton: {song.views}</p>
+        </Prose>
+
+        <div className="w-full h-96 relative overflow-hidden rounded-lg">
+          <Image
+            src={song.thumbnails}
+            alt={song.title}
+            fill
+            className="object-cover"
+          />
+        </div>
+
+        <Prose>
+          <h3>Lirik</h3>
+          <pre className="whitespace-pre-wrap font-sans">{song.lyrics.lyrics}</pre>
+        </Prose>
+      </Container>
+    </Section>
+  );
+}

--- a/lib/music.ts
+++ b/lib/music.ts
@@ -1,0 +1,45 @@
+export interface SongLyrics {
+  hasTimestamps: boolean;
+  lyrics: string;
+  source: string | null;
+}
+
+export interface SongData {
+  album: {
+    id: string;
+    name: string;
+  };
+  artists: {
+    id: string;
+    name: string;
+  }[];
+  duration: string;
+  found: boolean;
+  lyrics: SongLyrics;
+  query: string;
+  songArtistIds: string[];
+  thumbnails: string;
+  title: string;
+  videoId: string;
+  views: string;
+}
+
+const MUSIC_API_URL = process.env.MUSIC_API_URL;
+
+if (!MUSIC_API_URL) {
+  throw new Error("MUSIC_API_URL environment variable is not defined");
+}
+
+export async function getSongByTitle(title: string): Promise<SongData | null> {
+  try {
+    const response = await fetch(`${MUSIC_API_URL}/${encodeURIComponent(title)}`);
+    if (!response.ok) {
+      console.warn(`Music API request failed: ${response.statusText}`);
+      return null;
+    }
+    return (await response.json()) as SongData;
+  } catch (error) {
+    console.warn("Failed to fetch song data", error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add music API integration
- create `/song/[title]` route to show song info
- expand `.env.example` with `MUSIC_API_URL`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6862dda202788325b68424d4366c2e33